### PR TITLE
Persist announcements

### DIFF
--- a/announcement_config.py
+++ b/announcement_config.py
@@ -45,3 +45,26 @@
 ## Search paths for jinja templates, coming before default ones
 #c.AnnouncementService.template_paths = []
 
+#------------------------------------------------------------------------------
+# AnnouncementQueue(LoggingConfigurable) configuration
+#------------------------------------------------------------------------------
+
+## File path where announcements persist as JSON.
+#  
+#  For a persistent announcement queue, this parameter must be set to a non-empty
+#  value and correspond to a read+write-accessible path. The announcement queue
+#  is stored as a list of JSON objects. If this parameter is set to a non-empty
+#  value:
+#  
+#  * The persistence file is used to initialize the announcement queue
+#    at start-up. This is the only time the persistence file is read.
+#  * If the persistence file does not exist at start-up, it is
+#    created when an announcement is added to the queue.
+#  * The persistence file is over-written with the contents of the
+#    announcement queue each time a new announcement is added.
+#  
+#  If this parameter is set to an empty value (the default) then the queue is
+#  just empty at initialization and the queue is ephemeral; announcements will
+#  not be persisted on updates to the queue.
+#c.AnnouncementQueue.persist_path = ''
+

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ from distutils.core import setup
 
 setup(
         name='jupyterhub-announcement',
-        version='0.1.0',
+        version='0.2.0',
         description='JupyterHub Announcement Service',
         author='R. C. Thomas',
         author_email='rcthomas@lbl.gov',

--- a/templates/index.html
+++ b/templates/index.html
@@ -32,7 +32,7 @@
       <h2>Latest Announcement</h2>
     </div>
   </div>
-  {% for entry in storage | reverse %}
+  {% for entry in announcements | reverse %}
   {% if loop.index == 2 %}
     <div class="row"> 
       <div class="col-md-offset-3 col-md-6">


### PR DESCRIPTION
This allows announcements to be initialized from a previous list of persisted announcements and persist the list of announcements on update.  We just use a JSON file for the storage.

- Add configuration options for using persistent announcements
- Add logging though it's a bit weird with traitlets
- Change "storage" to "queue" and call it that throughout
- Make the persisted announcement queue be the storage mechanism
- Change template accordingly
- Increment version number