### PR TITLE
Add support of cross-origin resource sharing (CORS) requests for subdomains

### DIFF
--- a/announcement_config.py
+++ b/announcement_config.py
@@ -42,6 +42,9 @@
 ## Announcement service prefix
 #c.AnnouncementService.service_prefix = '/services/announcement/'
 
+## Allow access from subdomains
+#c.AnnouncementService.allow_origin = False
+
 ## Search paths for jinja templates, coming before default ones
 #c.AnnouncementService.template_paths = []
 


### PR DESCRIPTION
This merge request adds a new configuration variable `allow_origin` which is set to "False" by default (i.e. no change in the current behavior). When set to "True", three HTTP headers are added to the server's response when the latest announcement is requested through the REST API. Those headers add the support of CORS requests [1]. Therefore, all the subdomains of the deployed JupyterHub (ex: https://<username>.jupyter.company.org) can request and display the latest announcement.

[1] https://developer.mozilla.org/en-US/docs/Web/HTTP/CORS