### PR TITLE
Hook for extra info in the response

### DIFF
--- a/announcement_config.py
+++ b/announcement_config.py
@@ -18,6 +18,53 @@
 #  Default: 30
 # c.Application.log_level = 30
 
+## Configure additional log handlers.
+#
+#  The default stderr logs handler is configured by the log_level, log_datefmt
+#  and log_format settings.
+#
+#  This configuration can be used to configure additional handlers (e.g. to
+#  output the log to a file) or for finer control over the default handlers.
+#
+#  If provided this should be a logging configuration dictionary, for more
+#  information see:
+#  https://docs.python.org/3/library/logging.config.html#logging-config-
+#  dictschema
+#
+#  This dictionary is merged with the base logging configuration which defines
+#  the following:
+#
+#  * A logging formatter intended for interactive use called
+#    ``console``.
+#  * A logging handler that writes to stderr called
+#    ``console`` which uses the formatter ``console``.
+#  * A logger with the name of this application set to ``DEBUG``
+#    level.
+#
+#  This example adds a new handler that writes to a file:
+#
+#  .. code-block:: python
+#
+#     c.Application.logging_configuration = {
+#         'handlers': {
+#             'file': {
+#                 'class': 'logging.FileHandler',
+#                 'level': 'DEBUG',
+#                 'filename': '<path/to/file>',
+#             }
+#         },
+#         'loggers': {
+#             '<application-name>': {
+#                 'level': 'DEBUG',
+#                 # NOTE: if you don't list the default "console"
+#                 # handler here then it will be disabled
+#                 'handlers': ['console', 'file'],
+#             },
+#         }
+#     }
+#  Default: {}
+# c.Application.logging_config = {}
+
 ## Instead of starting the Application, dump configuration to stdout
 #  Default: False
 # c.Application.show_config = False
@@ -39,14 +86,18 @@
 #  Default: 'announcement_config.py'
 # c.AnnouncementService.config_file = 'announcement_config.py'
 
-## File in which to store the cookie secret.
+## File in which we store the cookie secret.
 #  Default: 'jupyterhub-announcement-cookie-secret'
 # c.AnnouncementService.cookie_secret_file = 'jupyterhub-announcement-cookie-secret'
 
+## Async callable to add extra info to the latest announcement.
+#  Default: None
+# c.AnnouncementService.extra_info_hook = None
+
 ## Fixed message to show at the top of the page.
 #
-#  A good use for this parameter would be a link to a more general
-#  live system status page or MOTD.
+#           A good use for this parameter would be a link to a more general
+#           live system status page or MOTD.
 #  Default: ''
 # c.AnnouncementService.fixed_message = ''
 
@@ -65,6 +116,10 @@
 ## Set the log level by value or name.
 #  See also: Application.log_level
 # c.AnnouncementService.log_level = 30
+
+##
+#  See also: Application.logging_config
+# c.AnnouncementService.logging_config = {}
 
 ## Logo path, can be used to override JupyterHub one
 #  Default: ''
@@ -95,28 +150,28 @@
 # ------------------------------------------------------------------------------
 ## Number of days to retain announcements.
 #
-#  Announcements that have been in the queue for this many days are
-#  purged from the queue.
+#          Announcements that have been in the queue for this many days are
+#          purged from the queue.
 #  Default: 7.0
 # c.AnnouncementQueue.lifetime_days = 7.0
 
 ## File path where announcements persist as JSON.
 #
-#  For a persistent announcement queue, this parameter must be set to
-#  a non-empty value and correspond to a read+write-accessible path.
-#  The announcement queue is stored as a list of JSON objects. If this
-#  parameter is set to a non-empty value:
+#          For a persistent announcement queue, this parameter must be set to
+#          a non-empty value and correspond to a read+write-accessible path.
+#          The announcement queue is stored as a list of JSON objects. If this
+#          parameter is set to a non-empty value:
 #
-#  * The persistence file is used to initialize the announcement queue
-#    at start-up. This is the only time the persistence file is read.
-#  * If the persistence file does not exist at start-up, it is
-#    created when an announcement is added to the queue.
-#  * The persistence file is over-written with the contents of the
-#    announcement queue each time a new announcement is added.
+#          * The persistence file is used to initialize the announcement queue
+#            at start-up. This is the only time the persistence file is read.
+#          * If the persistence file does not exist at start-up, it is
+#            created when an announcement is added to the queue.
+#          * The persistence file is over-written with the contents of the
+#            announcement queue each time a new announcement is added.
 #
-#  If this parameter is set to an empty value (the default) then the
-#  queue is just empty at initialization and the queue is ephemeral;
-#  announcements will not be persisted on updates to the queue.
+#          If this parameter is set to an empty value (the default) then the
+#          queue is just empty at initialization and the queue is ephemeral;
+#          announcements will not be persisted on updates to the queue.
 #  Default: ''
 # c.AnnouncementQueue.persist_path = ''
 

--- a/jupyterhub_announcement/announcement.py
+++ b/jupyterhub_announcement/announcement.py
@@ -1,10 +1,12 @@
 import binascii
+import logging
 import os
 import sys
 
 from jinja2 import ChoiceLoader, FileSystemLoader, PrefixLoader
 from jupyterhub._data import DATA_FILES_PATH
 from jupyterhub.handlers.static import LogoHandler
+from jupyterhub.log import CoroutineLogFormatter
 from jupyterhub.services.auth import HubOAuthCallbackHandler
 from jupyterhub.utils import url_path_join
 from tornado import gen, ioloop, web
@@ -93,6 +95,16 @@ class AnnouncementService(Application):
         help="Async callable to add extra info to the latest announcement.",
     ).tag(config=True)
 
+    _log_formatter_cls = CoroutineLogFormatter
+
+    @default("log_datefmt")
+    def _log_datefmt(self):
+        return "%Y-%m-%d %H:%M:%S"
+
+    @default("log_format")
+    def _log_format(self):
+        return "%(color)s[%(levelname)1.1s %(asctime)s.%(msecs).03d %(name)s %(module)s:%(lineno)d]%(end_color)s %(message)s"
+
     def initialize(self, argv=None):
         super().initialize(argv)
 
@@ -103,8 +115,8 @@ class AnnouncementService(Application):
         if self.config_file:
             self.load_config_file(self.config_file)
 
-        # Totally confused by traitlets logging
-        self.log.parent.setLevel(self.log.level)
+        #       # Totally confused by traitlets logging
+        #       self.log.parent.setLevel(self.log.level)
 
         self.init_queue()
         self.init_ssl_context()
@@ -127,6 +139,7 @@ class AnnouncementService(Application):
             "cookie_secret": cookie_secret,
             "static_path": os.path.join(self.data_files_path, "static"),
             "static_url_prefix": url_path_join(self.service_prefix, "static/"),
+            "log": self.log,
         }
 
         self.app = web.Application(
@@ -165,6 +178,30 @@ class AnnouncementService(Application):
             ],
             **self.settings,
         )
+
+    def init_logging(self):
+        # This prevents double log messages because tornado use a root logger
+        # that self.log is a child of. The logging module dipatches log
+        # messages to a log and all of its ancenstors until propagate is set to
+        # False.
+        self.log.propagate = False
+
+        # disable curl debug, which is TOO MUCH
+        logging.getLogger("tornado.curl_httpclient").setLevel(
+            max(self.log_level, logging.INFO)
+        )
+
+        for name in ("access", "application", "general"):
+            # ensure all log statements identify the application they come from
+            log = logging.getLogger(f"tornado.{name}")
+            log.name = self.log.name
+
+        # hook up tornado's and oauthlib's loggers to our own
+        for name in ("tornado", "oauthlib"):
+            logger = logging.getLogger(name)
+            logger.propagate = True
+            logger.parent = self.log
+            logger.setLevel(self.log.level)
 
     def init_queue(self):
         self.queue = AnnouncementQueue(log=self.log, config=self.config)

--- a/jupyterhub_announcement/announcement.py
+++ b/jupyterhub_announcement/announcement.py
@@ -8,7 +8,7 @@ from jupyterhub.handlers.static import LogoHandler
 from jupyterhub.services.auth import HubOAuthCallbackHandler
 from jupyterhub.utils import url_path_join
 from tornado import gen, ioloop, web
-from traitlets import Any, Bool, Dict, Integer, List, Unicode, default
+from traitlets import Any, Bool, Callable, Dict, Integer, List, Unicode, default
 from traitlets.config import Application
 
 from jupyterhub_announcement.handlers import (
@@ -87,6 +87,12 @@ class AnnouncementService(Application):
         help="File in which we store the cookie secret.",
     ).tag(config=True)
 
+    extra_info_hook = Callable(
+        None,
+        allow_none=True,
+        help="Async callable to add extra info to the latest announcement.",
+    ).tag(config=True)
+
     def initialize(self, argv=None):
         super().initialize(argv)
 
@@ -139,7 +145,11 @@ class AnnouncementService(Application):
                 (
                     self.service_prefix + r"latest",
                     AnnouncementLatestHandler,
-                    dict(queue=self.queue, allow_origin=self.allow_origin),
+                    dict(
+                        queue=self.queue,
+                        allow_origin=self.allow_origin,
+                        extra_info_hook=self.extra_info_hook,
+                    ),
                 ),
                 (
                     self.service_prefix + r"update",

--- a/jupyterhub_announcement/handlers.py
+++ b/jupyterhub_announcement/handlers.py
@@ -1,4 +1,5 @@
 import json
+import logging
 
 from html_sanitizer import Sanitizer
 from jinja2 import Environment
@@ -11,7 +12,12 @@ from jupyterhub_announcement.encoder import _JSONEncoder
 
 class AnnouncementHandler(HubOAuthenticated, web.RequestHandler):
     def initialize(self, queue):
+        super().initialize()
         self.queue = queue
+
+    @property
+    def log(self):
+        return self.settings.get("log", logging.getLogger("tornado.application"))
 
 
 class AnnouncementViewHandler(AnnouncementHandler):

--- a/jupyterhub_announcement/handlers.py
+++ b/jupyterhub_announcement/handlers.py
@@ -61,9 +61,9 @@ class AnnouncementLatestHandler(AnnouncementHandler):
         latest = {"announcement": ""}
         if self.queue.announcements:
             latest = self.queue.announcements[-1]
-        query_extra_info = self.get_query_argument("extra_info", "0").lower()
-        if (query_extra_info in ["1", "true"]) and self.extra_info_hook:
-            latest["extra_info"] = await self.extra_info_hook(self)
+        query_extra = self.get_query_argument("extra", "0").lower()
+        if (query_extra in ["1", "true"]) and self.extra_info_hook:
+            latest["extra"] = await self.extra_info_hook(self)
         self.set_header("Content-Type", "application/json; charset=UTF-8")
         if self.allow_origin:
             self.add_header("Access-Control-Allow-Headers", "Content-Type")

--- a/jupyterhub_announcement/handlers.py
+++ b/jupyterhub_announcement/handlers.py
@@ -46,14 +46,18 @@ class AnnouncementViewHandler(AnnouncementHandler):
 class AnnouncementLatestHandler(AnnouncementHandler):
     """Return the latest announcement as JSON"""
 
-    def initialize(self, queue, allow_origin):
+    def initialize(self, queue, allow_origin, extra_info_hook):
         super().initialize(queue)
         self.allow_origin = allow_origin
+        self.extra_info_hook = extra_info_hook
 
-    def get(self):
+    async def get(self):
         latest = {"announcement": ""}
         if self.queue.announcements:
             latest = self.queue.announcements[-1]
+        query_extra_info = self.get_query_argument("extra_info", "0").lower()
+        if (query_extra_info in ["1", "true"]) and self.extra_info_hook:
+            latest["extra_info"] = await self.extra_info_hook(self)
         self.set_header("Content-Type", "application/json; charset=UTF-8")
         if self.allow_origin:
             self.add_header("Access-Control-Allow-Headers", "Content-Type")


### PR DESCRIPTION
In addition the a message from the friendly system administrator, there may be extra information to convey to users that is gathered in a more automated fashion.  Perhaps your deployment runs alongside a nice REST API that can communicate status of various resources and systems at your center.  If a relevant resource changes status from "available" to "degraded" or "offline" you may want to reflect that to users automatically.  Or the coroutine could somehow verify the availability of the resource itself, it should just probably do that quickly and/or cache the result.

This PR introduces support an `extra_info_hook` configurable that is either a coroutine or `None`.  If configured, the coroutine should take a handler as its sole argument, most likely for unified logging.  It should return something JSON-serializable, in particular a list or dict.  This response is then added to the `latest` announcement response in a field called `extra`, if the caller has specified `?extra=1` or `?extra=true`.  Otherwise the `extra_info_hook` is not executed.  Also, if the hook is not configured but the caller specifies `?extra=1` it is just ignored and the `extra` field is not added to the response.





