### PR TITLE
Add Endpoint for listing last N announcements.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -110,3 +110,6 @@ dmypy.json
 # End of https://www.gitignore.io/api/python
 
 .DS_Store
+
+# IDE files
+.idea

--- a/jupyterhub_announcement/announcement.py
+++ b/jupyterhub_announcement/announcement.py
@@ -15,6 +15,7 @@ from traitlets.config import Application
 
 from jupyterhub_announcement.handlers import (
     AnnouncementLatestHandler,
+    AnnouncementListHandler,
     AnnouncementUpdateHandler,
     AnnouncementViewHandler,
 )
@@ -47,6 +48,8 @@ class AnnouncementService(Application):
     ).tag(config=True)
 
     port = Integer(8888, help="Port this service will listen on").tag(config=True)
+
+    list_limit = Integer(5, help="Limit for number of announcements to return in list endpoint").tag(config=True)
 
     allow_origin = Bool(False, help="Allow access from subdomains").tag(config=True)
 
@@ -162,6 +165,12 @@ class AnnouncementService(Application):
                         queue=self.queue,
                         allow_origin=self.allow_origin,
                         extra_info_hook=self.extra_info_hook,
+                    ),
+                ),
+                (
+                    self.service_prefix + r"list", AnnouncementListHandler,
+                    dict(
+                        queue=self.queue, allow_origin=self.allow_origin, list_limit=self.list_limit,
                     ),
                 ),
                 (

--- a/jupyterhub_announcement/announcement.py
+++ b/jupyterhub_announcement/announcement.py
@@ -49,7 +49,13 @@ class AnnouncementService(Application):
 
     port = Integer(8888, help="Port this service will listen on").tag(config=True)
 
-    list_limit = Integer(5, help="Limit for number of announcements to return in list endpoint").tag(config=True)
+    default_limit = Integer(
+        5,
+        help=(
+            "Default limit for number of announcements to return in list endpoint "
+            "if parameter is not specified"
+        )
+    ).tag(config=True)
 
     allow_origin = Bool(False, help="Allow access from subdomains").tag(config=True)
 
@@ -170,7 +176,7 @@ class AnnouncementService(Application):
                 (
                     self.service_prefix + r"list", AnnouncementListHandler,
                     dict(
-                        queue=self.queue, allow_origin=self.allow_origin, list_limit=self.list_limit,
+                        queue=self.queue, allow_origin=self.allow_origin, default_limit=self.default_limit,
                     ),
                 ),
                 (

--- a/jupyterhub_announcement/handlers.py
+++ b/jupyterhub_announcement/handlers.py
@@ -58,7 +58,7 @@ class AnnouncementLatestHandler(AnnouncementHandler):
         self.allow_origin = allow_origin
         self.extra_info_hook = extra_info_hook
 
-    async def write_output(self, output):
+    def write_output(self, output):
         self.set_header("Content-Type", "application/json; charset=UTF-8")
         if self.allow_origin:
             self.add_header("Access-Control-Allow-Headers", "Content-Type")
@@ -80,7 +80,7 @@ class AnnouncementLatestHandler(AnnouncementHandler):
                     latest["announcement"] += "<br>" + extra_info
                 else:
                     latest["announcement"] = extra_info
-        await self.write_output(latest)
+        self.write_output(latest)
 
 
 class AnnouncementListHandler(AnnouncementLatestHandler):
@@ -90,7 +90,7 @@ class AnnouncementListHandler(AnnouncementLatestHandler):
         output = []
         if self.queue.announcements:
             output = [dict(a) for a in self.queue.announcements[-self.list_limit:]]
-        await self.write_output(output)
+        self.write_output(output)
 
 
 class AnnouncementUpdateHandler(AnnouncementHandler):

--- a/jupyterhub_announcement/handlers.py
+++ b/jupyterhub_announcement/handlers.py
@@ -45,6 +45,7 @@ class AnnouncementViewHandler(AnnouncementHandler):
                 logout_url=logout_url,
                 base_url=prefix,
                 no_spawner_check=True,
+                parsed_scopes=user.get("hub_scopes") or [],
             )
         )
 

--- a/jupyterhub_announcement/handlers.py
+++ b/jupyterhub_announcement/handlers.py
@@ -86,10 +86,16 @@ class AnnouncementLatestHandler(AnnouncementHandler):
 class AnnouncementListHandler(AnnouncementLatestHandler):
     """Return the latest announcement as JSON"""
 
+    def initialize(self, queue, allow_origin, list_limit=5):
+        super().initialize(queue)
+        self.allow_origin = allow_origin
+        self.list_limit = list_limit
+
     async def get(self):
         output = []
+        limit = self.get_arguments("limit") or self.list_limit
         if self.queue.announcements:
-            output = [dict(a) for a in self.queue.announcements[-self.list_limit:]]
+            output = [dict(a) for a in self.queue.announcements[-limit:]]
         self.write_output(output)
 
 

--- a/jupyterhub_announcement/handlers.py
+++ b/jupyterhub_announcement/handlers.py
@@ -79,6 +79,26 @@ class AnnouncementLatestHandler(AnnouncementHandler):
         self.write(escape.utf8(json.dumps(latest, cls=_JSONEncoder)))
 
 
+class AnnouncementListHandler(AnnouncementHandler):
+    """Return the latest announcement as JSON"""
+
+    def initialize(self, queue, allow_origin, list_limit=5):
+        super().initialize(queue)
+        self.allow_origin = allow_origin
+        self.list_limit = list_limit
+
+    async def get(self):
+        outputs = []
+        if self.queue.announcements:
+            outputs = [dict(a) for a in self.queue.announcements[-self.list_limit:]]
+        self.set_header("Content-Type", "application/json; charset=UTF-8")
+        if self.allow_origin:
+            self.add_header("Access-Control-Allow-Headers", "Content-Type")
+            self.add_header("Access-Control-Allow-Origin", "*")
+            self.add_header("Access-Control-Allow-Methods", "OPTIONS,GET")
+        self.write(escape.utf8(json.dumps(outputs, cls=_JSONEncoder)))
+
+
 class AnnouncementUpdateHandler(AnnouncementHandler):
     """Update announcements page"""
 


### PR DESCRIPTION
I made a new endpoint to allow users to display more than one announcement at a time. I also added parsed-scopes to the jinja parameters so this will work with `jupyterhub>=3.0.0`.