### PR TITLE
Ensure only admin users can update announcements

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -12,19 +12,24 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.8", "3.9", "3.10"]
+        python-version: ["3.9", "3.13"]
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v3
+      uses: actions/setup-python@v5
       with:
         python-version: ${{ matrix.python-version }}
+    - name: Set up Node.js
+      uses: actions/setup-node@v4
+      with:
+        node-version: 20.x
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
         if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
         if [ -f requirements-dev.txt ]; then pip install -r requirements-dev.txt; fi
+        npm install -g configurable-http-proxy
     - name: Lint with flake8
       run: |
         # stop the build if there are Python syntax errors or undefined names

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -30,6 +30,7 @@ jobs:
         if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
         if [ -f requirements-dev.txt ]; then pip install -r requirements-dev.txt; fi
         npm install -g configurable-http-proxy
+        pip install -e .
     - name: Lint with flake8
       run: |
         # stop the build if there are Python syntax errors or undefined names

--- a/jupyterhub_announcement/announcement.py
+++ b/jupyterhub_announcement/announcement.py
@@ -12,7 +12,7 @@ from jupyterhub.handlers.static import LogoHandler
 from jupyterhub.log import CoroutineLogFormatter
 from jupyterhub.services.auth import HubOAuthCallbackHandler
 from jupyterhub.utils import url_path_join
-from tornado import gen, ioloop, web
+from tornado import ioloop, web
 from traitlets import Any, Bool, Callable, Dict, Integer, List, Unicode, default
 from traitlets.config import Application
 
@@ -142,9 +142,9 @@ class AnnouncementService(Application):
         self.init_ssl_context()
         self.init_secrets()
 
-        base_path = self._template_paths_default()[0]
-        if base_path not in self.template_paths:
-            self.template_paths.append(base_path)
+        for base_path in self._template_paths_default():
+            if base_path not in self.template_paths:
+                self.template_paths.append(base_path)
         loader = ChoiceLoader(
             [
                 PrefixLoader({"templates": FileSystemLoader([base_path])}, "/"),
@@ -250,7 +250,7 @@ class AnnouncementService(Application):
                 """
                     ).format(secret_file)
                 )
-        except Exception as e:
+        except Exception:
             self.log.debug("Generating new cookie secret")
             secret = secrets.token_bytes(COOKIE_SECRET_BYTES)
             # if we generated a new secret, store it in the secret_file
@@ -259,7 +259,7 @@ class AnnouncementService(Application):
             with open(secret_file, 'w') as f:
                 f.write(text_secret)
                 f.write('\n')
-        
+
         # store the loaded trait value
         self.cookie_secret = secret
 

--- a/jupyterhub_announcement/handlers.py
+++ b/jupyterhub_announcement/handlers.py
@@ -118,7 +118,7 @@ class AnnouncementUpdateHandler(AnnouncementHandler):
         # Check if user is admin. If not raise a 403
         if not user["admin"]:
             raise web.HTTPError(
-                403, f"{user['admin']} is not authorized to update announcement"
+                403, f"{user['name']} is not authorized to update announcement"
             )
         sanitizer = Sanitizer()
         announcement = sanitizer.sanitize(self.get_body_argument("announcement"))

--- a/jupyterhub_announcement/handlers.py
+++ b/jupyterhub_announcement/handlers.py
@@ -47,7 +47,7 @@ class AnnouncementViewHandler(AnnouncementHandler):
                 logout_url=logout_url,
                 base_url=prefix,
                 no_spawner_check=True,
-                parsed_scopes=user.get("hub_scopes") or [],
+                parsed_scopes=user.get("scopes") or [],
                 xsrf_form_html=self.xsrf_form_html,
                 update_url=update_url,
             )
@@ -71,8 +71,6 @@ class AnnouncementLatestHandler(AnnouncementOutputHandler):
         super().initialize(queue)
         self.allow_origin = allow_origin
         self.extra_info_hook = extra_info_hook
-
-
 
     async def get(self):
         latest = {"announcement": ""}
@@ -117,6 +115,11 @@ class AnnouncementUpdateHandler(AnnouncementHandler):
     async def post(self):
         """Update announcement"""
         user = self.get_current_user()
+        # Check if user is admin. If not raise a 403
+        if not user["admin"]:
+            raise web.HTTPError(
+                403, f"{user['admin']} is not authorized to update announcement"
+            )
         sanitizer = Sanitizer()
         announcement = sanitizer.sanitize(self.get_body_argument("announcement"))
         await self.queue.update(user["name"], announcement)

--- a/jupyterhub_announcement/ssl.py
+++ b/jupyterhub_announcement/ssl.py
@@ -1,4 +1,5 @@
 import os
+import ssl
 
 from jupyterhub.utils import make_ssl_context
 from traitlets import Unicode
@@ -23,7 +24,7 @@ class SSLContext(Configurable):
     def ssl_context(self):
         if self.keyfile and self.certfile and self.cafile:
             return make_ssl_context(
-                self.keyfile, self.certfile, cafile=self.cafile, check_hostname=False
+                self.keyfile, self.certfile, cafile=self.cafile, purpose=ssl.Purpose.CLIENT_AUTH,
             )
         else:
             return None

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,75 @@
+import time
+import pytest
+import socket
+import subprocess
+
+
+@pytest.fixture(scope="session")
+def jupyterhub_server(tmp_path_factory):
+    jupyterhub_dir = tmp_path_factory.mktemp("jupyterhub")
+    jupyterhub_config_file = jupyterhub_dir / "config.py"
+    config_content = """
+import os
+import sys
+
+CUSTOM_TEMPLATES_PATH = os.path.join(
+    sys.prefix, 'share', 'jupyterhub', 'announcement', 'templates'
+)
+
+c.Application.log_level = 10
+
+c.JupyterHub.services = [
+    {
+        'name': 'announcement',
+        'url': 'http://127.0.0.1:8888',
+        'command': ["python", "-m", "jupyterhub_announcement"],
+        'oauth_no_confirm': True,
+    }
+]
+
+c.JupyterHub.load_roles = [
+    {
+        "name": "user",
+        "scopes": ["access:services!service=announcement", "self"],
+    }
+]
+
+c.JupyterHub.authenticator_class = 'jupyterhub.auth.DummyAuthenticator'
+c.Authenticator.allow_all = True
+c.Authenticator.admin_users = ['admin']
+
+c.JupyterHub.template_paths = [CUSTOM_TEMPLATES_PATH]
+
+c.JupyterHub.spawner_class = 'jupyterhub.spawner.SimpleLocalProcessSpawner'
+"""
+    with open(jupyterhub_config_file, 'w') as f:
+        f.write(config_content)
+
+    proc = subprocess.Popen(
+        [
+            "jupyterhub",
+            "--config",
+            jupyterhub_config_file
+        ],
+        cwd=jupyterhub_dir,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.STDOUT,
+    )
+
+    # Check it started successfully with a timeout of 60s
+    start = time.time()
+    while not is_server_up(8000) and time.time() - start < 60:
+        time.sleep(5)
+
+    yield proc
+
+    # Shut it down at the end of the pytest session
+    proc.terminate() 
+
+
+def is_server_up(port):
+    try:
+        with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
+            return s.connect_ex(('localhost', port)) == 0
+    except:
+        return False

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,47 +1,47 @@
 import time
+import pathlib
 import pytest
 import socket
 import subprocess
+
+
+ROOT_DIR = str(pathlib.Path(__file__).resolve().parent.parent)
 
 
 @pytest.fixture(scope="session")
 def jupyterhub_server(tmp_path_factory):
     jupyterhub_dir = tmp_path_factory.mktemp("jupyterhub")
     jupyterhub_config_file = jupyterhub_dir / "config.py"
-    config_content = """
-import os
-import sys
-
-CUSTOM_TEMPLATES_PATH = os.path.join(
-    sys.prefix, 'share', 'jupyterhub', 'announcement', 'templates'
-)
-
+    config_content = f"""
 c.Application.log_level = 10
 
 c.JupyterHub.services = [
-    {
+    {{
         'name': 'announcement',
         'url': 'http://127.0.0.1:8888',
-        'command': ["python", "-m", "jupyterhub_announcement"],
+        'command': [
+            "python", "-m", 
+            "jupyterhub_announcement", 
+            "--AnnouncementService.template_paths", "['{ROOT_DIR}/templates']"
+        ],
         'oauth_no_confirm': True,
-    }
+    }}
 ]
 
 c.JupyterHub.load_roles = [
-    {
+    {{
         "name": "user",
         "scopes": ["access:services!service=announcement", "self"],
-    }
+    }}
 ]
 
 c.JupyterHub.authenticator_class = 'jupyterhub.auth.DummyAuthenticator'
 c.Authenticator.allow_all = True
 c.Authenticator.admin_users = ['admin']
 
-c.JupyterHub.template_paths = [CUSTOM_TEMPLATES_PATH]
-
 c.JupyterHub.spawner_class = 'jupyterhub.spawner.SimpleLocalProcessSpawner'
 """
+
     with open(jupyterhub_config_file, 'w') as f:
         f.write(config_content)
 
@@ -64,12 +64,12 @@ c.JupyterHub.spawner_class = 'jupyterhub.spawner.SimpleLocalProcessSpawner'
     yield proc
 
     # Shut it down at the end of the pytest session
-    proc.terminate() 
+    proc.terminate()
 
 
 def is_server_up(port):
     try:
         with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
             return s.connect_ex(('localhost', port)) == 0
-    except:
+    except Exception:
         return False

--- a/tests/test_announcement.py
+++ b/tests/test_announcement.py
@@ -1,5 +1,3 @@
-import os
-import subprocess
 import requests
 import pytest
 
@@ -35,13 +33,13 @@ def test_api_resources(jupyterhub_server, user):
 
         # Goto announcements page
         announcement = session.get(
-            f"http://localhost:8000/services/announcement/"
+            "http://localhost:8000/services/announcement/"
         )
         assert announcement.status_code == 200
 
         # Get latest announcement
         latest = session.get(
-            f"http://localhost:8000/services/announcement/latest"
+            "http://localhost:8000/services/announcement/latest"
         )
         assert latest.status_code == 200
 

--- a/tests/test_announcement.py
+++ b/tests/test_announcement.py
@@ -1,0 +1,62 @@
+import os
+import subprocess
+import requests
+import pytest
+
+
+@pytest.mark.parametrize("user", ["normal", "admin"])
+def test_api_resources(jupyterhub_server, user):
+    """Test to check if announcement endpoints are working"""
+    # Auth data
+    auth_payload = {
+        'username': user,
+        'password': 'pass',
+    }
+    # Announcement data
+    announcement_payload = {
+        'announcement': 'This is test announcement',
+    }
+
+    # Open a session to login and test API resources
+    with requests.Session() as session:
+        # Go to login page to fetch XSRF token
+        login = session.get("http://localhost:8000/hub/login")
+        assert login.status_code == 200
+
+        # Get XSRF session cookie and update payload
+        cookie = login.cookies['_xsrf']
+        auth_payload.update({
+            '_xsrf': cookie
+        })
+
+        # Login into hub
+        auth = session.post("http://localhost:8000/hub/login", data=auth_payload)
+        assert auth.status_code == 200
+
+        # Goto announcements page
+        announcement = session.get(
+            f"http://localhost:8000/services/announcement/"
+        )
+        assert announcement.status_code == 200
+
+        # Get latest announcement
+        latest = session.get(
+            f"http://localhost:8000/services/announcement/latest"
+        )
+        assert latest.status_code == 200
+
+        # Get XSRF cookie for announcement service. These cookies are
+        # tied to path so we cannot use cookie of /hub/home
+        cookie = session.cookies.get(name='_xsrf', path='/services/announcement/')
+
+        # Make a post request to update announcement. Should be 403 for regular
+        # user and 200 for admin user
+        announcement = session.post(
+            f"http://localhost:8000/services/announcement/update?_xsrf={cookie}",
+            data=announcement_payload,
+        )
+        if user == 'admin':
+            expected = 200
+        else:
+            expected = 403
+        assert announcement.status_code == expected


### PR DESCRIPTION
* This PR adds a check in update handler to ensure only admin users can update the announcement
* Unit tests have been added to verify the behaviour
* Cookie secret will be generated by the package and written to a file when not provided
* CI workflows have been updated

Closes #33